### PR TITLE
Feat/add synchronized condition

### DIFF
--- a/src/main/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateService.java
+++ b/src/main/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateService.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 @Service
@@ -28,68 +29,83 @@ public class ExchangeRateService {
 	private final ExchangeRateMananaService mananaService;
 	private final ExchangeRateGoogleFinanceScraper googleFinanceScraper;
 
-	private final ConcurrentHashMap<Currency, ReentrantLock> currencyLocks = new ConcurrentHashMap<>();
-	private final Map<Currency, ExchangeRateStatus> exchangeRateResults = new ConcurrentHashMap<>();
-	private final long CACHE_EXPIRY_TIME = 2000;
+	private static final Map<Currency, ReentrantLock> currencyLocks = new ConcurrentHashMap<>();
+	private static final Map<Currency, Condition> currencyConditions = new ConcurrentHashMap<>();
+	private static final Map<Currency, ExchangeRateStatus> exchangeRateResults = new ConcurrentHashMap<>();
+
+	private static final long TRY_LOCK_TIMEOUT = 1;
+	private static final long CACHE_EXPIRY_TIME = 2000;
+	private static final long OPEN_API_TIMEOUT = 2000;
+	private static final long CONDITION_WAIT_TIMEOUT = 3000;
 
 	private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 		.withZone(ZoneId.systemDefault());
 
-	public void updateExchangeRate(Currency fromCurrency, Currency toCurrency) {
+	public BigDecimal getLatestExchangeRate(Currency fromCurrency, Currency toCurrency) {
 		if(isAvailableExchangeRate(fromCurrency, toCurrency)) {
-			return;
+			return exchangeRateResults.get(fromCurrency).exchangeRate;
 		}
 
 		ReentrantLock lock = currencyLocks.computeIfAbsent(fromCurrency, k -> new ReentrantLock());
-//		try {
-			if (lock.tryLock()) {  // TODO: tryLock(500, TimeUnit.MILLISECONDS) 설정
-				try {
-					// double checking
-					if (isAvailableExchangeRate(fromCurrency, toCurrency)) {
-						return;
-					}
-
-					CompletableFuture
-						.supplyAsync(() -> naverService.getExchangeRate(fromCurrency, toCurrency))
-						.orTimeout(CACHE_EXPIRY_TIME, TimeUnit.MILLISECONDS)
-						.thenApply(result -> new BigDecimal(result.toString())
-							.setScale(2, RoundingMode.CEILING))
-						.thenApply(exchangeRate -> {
-							updateExchangeRateStatus(fromCurrency, exchangeRate);
-
-							log.info("[Main(Naver)] {} 환율 {} 업데이트, {}",
-								fromCurrency,
-								exchangeRate,
-								formatter.format(Instant.ofEpochMilli(exchangeRateResults.get(fromCurrency).lastCachedTime)));
-							return exchangeRate;
-						})
-						.exceptionally(ex -> {
-							log.error("Naver API failed or timed out, calling Manana and Google... {}", ex.getMessage());
-							fallbackUpdate(fromCurrency, toCurrency);
-							return null;
-						}).join();
-				} finally {
-					lock.unlock();
-				}
+		Condition condition = currencyConditions.computeIfAbsent(fromCurrency, k -> lock.newCondition());
+		try {
+			if (lock.tryLock(TRY_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
+				return fetchPrimaryExchangeRate(fromCurrency, toCurrency, lock, condition);
 			} else {
-				log.info("다른 스레드에 의해 {} 단위가 업데이트 중입니다.", fromCurrency);
+				return monitorExchangeRateUpdate(fromCurrency, toCurrency, lock, condition);
 			}
-//		} catch (InterruptedException e) {
-//			log.error("{} ReentrantLock 획득 중 스레드 인터럽트 발생: {}", fromCurrency, e.getMessage());
-//		}
+		} catch (InterruptedException e) {
+			log.error("{} ReentrantLock 획득 중 스레드 인터럽트 발생: {}", fromCurrency, e.getMessage());
+			Thread.currentThread().interrupt();
+			throw new RuntimeException(e);
+		}
 	}
 
-	private void fallbackUpdate(Currency fromCurrency, Currency toCurrency) {
-		CompletableFuture
+	private BigDecimal fetchPrimaryExchangeRate(Currency fromCurrency, Currency toCurrency, ReentrantLock lock, Condition condition) {
+		try {
+			// double checking
+			if(isAvailableExchangeRate(fromCurrency, toCurrency)) {
+				return exchangeRateResults.get(fromCurrency).exchangeRate;
+			}
+
+			return CompletableFuture
+				.supplyAsync(() -> naverService.getExchangeRate(fromCurrency, toCurrency))
+				.orTimeout(OPEN_API_TIMEOUT, TimeUnit.MILLISECONDS)
+				.thenApply(result -> new BigDecimal(result.toString())
+					.setScale(2, RoundingMode.CEILING))
+				.thenApply(exchangeRate -> {
+					updateExchangeRateStatus(fromCurrency, exchangeRate);
+
+					log.info("[Main(Naver)] {} 환율 {} 업데이트, {}",
+						fromCurrency,
+						exchangeRate,
+						formatter.format(Instant.ofEpochMilli(exchangeRateResults.get(fromCurrency).lastCachedTime)));
+
+					return exchangeRate;
+				})
+				.exceptionally(ex -> {
+					log.error("Naver API failed or timed out, calling Manana and Google... {}", ex.getMessage());
+					return fetchFallbackExchangeRate(fromCurrency, toCurrency);
+				}).join();
+		} finally {
+			synchronized (condition) {
+				condition.notifyAll();
+			}
+			lock.unlock();
+		}
+	}
+
+	private BigDecimal fetchFallbackExchangeRate(Currency fromCurrency, Currency toCurrency) {
+		return CompletableFuture
 			.anyOf(
 				CompletableFuture
 					.supplyAsync(() -> mananaService.getExchangeRate(fromCurrency, toCurrency))
-					.orTimeout(CACHE_EXPIRY_TIME, TimeUnit.MILLISECONDS),
+					.orTimeout(OPEN_API_TIMEOUT, TimeUnit.MILLISECONDS),
 
 				CompletableFuture
 					.supplyAsync(() -> googleFinanceScraper.getExchangeRate(fromCurrency, toCurrency))
-					.orTimeout(CACHE_EXPIRY_TIME, TimeUnit.MILLISECONDS))
-
+					.orTimeout(OPEN_API_TIMEOUT, TimeUnit.MILLISECONDS)
+			)
 			.thenApply(result -> new BigDecimal(result.toString())
 				.setScale(2, RoundingMode.CEILING))
 			.thenApply(exchangeRate -> {
@@ -109,22 +125,45 @@ public class ExchangeRateService {
 			.join();
 	}
 
+	private BigDecimal monitorExchangeRateUpdate(Currency fromCurrency, Currency toCurrency, ReentrantLock lock, Condition condition) throws InterruptedException {
+		try {
+			// double checking
+			if(isAvailableExchangeRate(fromCurrency, toCurrency)) {
+				return exchangeRateResults.get(fromCurrency).exchangeRate;
+			}
+
+			log.info("다른 스레드에 의해 {} 단위가 업데이트 중입니다.", fromCurrency);
+
+			while (!isAvailableExchangeRate(fromCurrency, toCurrency)) {
+				if(lock.tryLock(TRY_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
+					return fetchPrimaryExchangeRate(fromCurrency, toCurrency, lock, condition);
+				}
+				else {
+					synchronized (condition) {
+						condition.wait(CONDITION_WAIT_TIMEOUT);
+					}
+				}
+			}
+			return exchangeRateResults.get(fromCurrency).exchangeRate;
+		} finally {
+			if(lock.isHeldByCurrentThread()) {
+				lock.unlock();
+			}
+		}
+	}
+
 	private void updateExchangeRateStatus(Currency fromCurrency, BigDecimal exchangeRate) {
 		ExchangeRateStatus status = exchangeRateResults.computeIfAbsent(fromCurrency, k -> new ExchangeRateStatus());
 		status.exchangeRate = exchangeRate;
 		status.lastCachedTime = System.currentTimeMillis();
 	}
 
-	public boolean isAvailableExchangeRate(Currency fromCurrency, Currency toCurrency) {
+	private boolean isAvailableExchangeRate(Currency fromCurrency, Currency toCurrency) {
 		return exchangeRateResults.containsKey(fromCurrency)
 			&& System.currentTimeMillis() - exchangeRateResults.get(fromCurrency).lastCachedTime < CACHE_EXPIRY_TIME;
 	}
 
-	public BigDecimal getExchangeRate(Currency fromCurrency, Currency toCurrency) {
-		return exchangeRateResults.get(fromCurrency).exchangeRate;
-	}
-
-	class ExchangeRateStatus {
+	static class ExchangeRateStatus {
 		BigDecimal exchangeRate;
 		Long lastCachedTime;
 

--- a/src/main/java/com/nayoung/exchangerateopenapitest/domain/transaction/service/TransactionService.java
+++ b/src/main/java/com/nayoung/exchangerateopenapitest/domain/transaction/service/TransactionService.java
@@ -36,34 +36,10 @@ public class TransactionService {
 			exchangeRate = new BigDecimal(1);
 		}
 		else {
-			long currentTime = System.currentTimeMillis();
-			long timeout = 4000;
-			long endTime = currentTime + timeout;
-
-			boolean timeoutFlag = true;
-			while (System.currentTimeMillis() < endTime) {
-				// 로컬 캐시 사용
-				if (exchangeRateService.isAvailableExchangeRate(receiverAccount.getCurrency(), senderAccount.getCurrency())) {
-					exchangeRate = exchangeRateService.getExchangeRate(receiverAccount.getCurrency(), senderAccount.getCurrency());
-					timeoutFlag = false;
-					break;
-				}
-
-				// 실시간 환율 데이터 업데이트 (스레드 1개로 제한)
-				exchangeRateService.updateExchangeRate(receiverAccount.getCurrency(), senderAccount.getCurrency());
-
-				try {
-					if (!exchangeRateService.isAvailableExchangeRate(receiverAccount.getCurrency(), senderAccount.getCurrency())) {
-						Thread.sleep(150);
-					}
-				} catch (InterruptedException e) {
-					Thread.currentThread().interrupt();
-					throw new RuntimeException("환율 조회 중 인터럽트 발생", e);
-				}
-			}
-
-			if (timeoutFlag || exchangeRate.compareTo(BigDecimal.ZERO) <= 0) {
-				log.warn("[ Timeout ] 현재 실시간 환율을 이용할 수 없습니다. " + Thread.currentThread().getName());
+			try {
+				exchangeRate = exchangeRateService.getLatestExchangeRate(receiverAccount.getCurrency(), senderAccount.getCurrency());
+			} catch (Exception e) {
+				log.warn("[ Timeout ] 현재 실시간 환율을 이용할 수 없습니다.", e);
 				throw new RuntimeException("현재 실시간 환율을 이용할 수 없습니다.");
 			}
 		}

--- a/src/test/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateServiceMockTest.java
+++ b/src/test/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateServiceMockTest.java
@@ -37,7 +37,7 @@ class ExchangeRateServiceMockTest {
 		for(int i = 0; i < threadCount; i++) {
 			executorService.submit(() -> {
 				try {
-					exchangeRateService.updateExchangeRate(Currency.USD, Currency.KRW);
+					exchangeRateService.getLatestExchangeRate(Currency.USD, Currency.KRW);
 				} finally {
 					countDownLatch.countDown();
 				}


### PR DESCRIPTION
### lock.lock() 제거

- 소비자 스레드(로컬 캐시 업데이트를 기다리는)가 깨어난 후 ReentrantLock을 바로 잡을 필요 없고
- 소비자 메서드(monitorExchangeRateUpdate)에 lock.lock() 추가하면 결국 소비자가 순차처리 되는데, 구현 의도와 다름

### synchronized (condition) 설정
```java
synchronized (condition) {
	condition.wait(CONDITION_WAIT_TIMEOUT);
}
```
- 동기화가 필요 없어서 위와 같이 작성해 여러 소비자 스레드가 거의 동시에 wait 하게 했지만,
- synchronized + condition(lock 없이) 조합이 과연 기술의 특성을 잘 살린 것인지 알 수 없음 (condition은 lock과 함께 사용하는 것으로 알고 있음)