### PR TITLE
feat: add future complete get

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ private BigDecimal monitorExchangeRateUpdate(Currency fromCurrency, Currency toC
 	}
 }
 ```
-- https://드ithub.com/imzero238/exchange-rate-open-api-test/blob/feat/add-cv/src/main/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateService.java
-
+- https://github.com/imzero238/exchange-rate-open-api-test/blob/feat/add-cv/src/main/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateService.java
 - 구현 의도대로 1개의 스레드만 Open API를 호출하지만
 - 생산자, 소비자 모두 같은 락을 획득하려고 하기 떄문에, 소비자는 await 지점에서 대기하는 것이 아니라 lock.lock() 지점에서 대기
 - 즉, 이론으로 배웠던 생산자, 소비자 문제(누가 먼저 공유 자원에 접근하는지 파악 불가)와 다르게 생산자가 무조건 lock을 먼저 획득한다는 차이
 - 이 코드에선 await가 필요하지 않을 수 있다고 판단해 방법 2로 변경했습니다!
+<br>
 
 - [소비자 await 코드 라인](https://github.com/imzero238/exchange-rate-open-api-test/blob/feat/add-cv/src/main/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateService.java#L142) 위 링크와 같습니다.
 - [생산자 signalAll 코드 라인](https://github.com/imzero238/exchange-rate-open-api-test/blob/feat/add-cv/src/main/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateService.java#L90) 위 링크와 같습니다.

--- a/src/main/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateService.java
+++ b/src/main/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateService.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 @Service
@@ -28,68 +29,83 @@ public class ExchangeRateService {
 	private final ExchangeRateMananaService mananaService;
 	private final ExchangeRateGoogleFinanceScraper googleFinanceScraper;
 
-	private final ConcurrentHashMap<Currency, ReentrantLock> currencyLocks = new ConcurrentHashMap<>();
-	private final Map<Currency, ExchangeRateStatus> exchangeRateResults = new ConcurrentHashMap<>();
-	private final long CACHE_EXPIRY_TIME = 2000;
+	private static final Map<Currency, ReentrantLock> currencyLocks = new ConcurrentHashMap<>();
+	private static final Map<Currency, Condition> currencyConditions = new ConcurrentHashMap<>();
+	private static final Map<Currency, ExchangeRateStatus> exchangeRateResults = new ConcurrentHashMap<>();
+
+	private static final long TRY_LOCK_TIMEOUT = 1;
+	private static final long CACHE_EXPIRY_TIME = 2000;
+	private static final long OPEN_API_TIMEOUT = 2000;
+	private static final long CONDITION_WAIT_TIMEOUT = 3000;
 
 	private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 		.withZone(ZoneId.systemDefault());
 
-	public void updateExchangeRate(Currency fromCurrency, Currency toCurrency) {
+	public BigDecimal getLatestExchangeRate(Currency fromCurrency, Currency toCurrency) {
 		if(isAvailableExchangeRate(fromCurrency, toCurrency)) {
-			return;
+			return exchangeRateResults.get(fromCurrency).exchangeRate;
 		}
 
 		ReentrantLock lock = currencyLocks.computeIfAbsent(fromCurrency, k -> new ReentrantLock());
-//		try {
-			if (lock.tryLock()) {  // TODO: tryLock(500, TimeUnit.MILLISECONDS) 설정
-				try {
-					// double checking
-					if (isAvailableExchangeRate(fromCurrency, toCurrency)) {
-						return;
-					}
-
-					CompletableFuture
-						.supplyAsync(() -> naverService.getExchangeRate(fromCurrency, toCurrency))
-						.orTimeout(CACHE_EXPIRY_TIME, TimeUnit.MILLISECONDS)
-						.thenApply(result -> new BigDecimal(result.toString())
-							.setScale(2, RoundingMode.CEILING))
-						.thenApply(exchangeRate -> {
-							updateExchangeRateStatus(fromCurrency, exchangeRate);
-
-							log.info("[Main(Naver)] {} 환율 {} 업데이트, {}",
-								fromCurrency,
-								exchangeRate,
-								formatter.format(Instant.ofEpochMilli(exchangeRateResults.get(fromCurrency).lastCachedTime)));
-							return exchangeRate;
-						})
-						.exceptionally(ex -> {
-							log.error("Naver API failed or timed out, calling Manana and Google... {}", ex.getMessage());
-							fallbackUpdate(fromCurrency, toCurrency);
-							return null;
-						}).join();
-				} finally {
-					lock.unlock();
-				}
+		Condition condition = currencyConditions.computeIfAbsent(fromCurrency, k -> lock.newCondition());
+		try {
+			if (lock.tryLock(TRY_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
+				return fetchPrimaryExchangeRate(fromCurrency, toCurrency, lock, condition);
 			} else {
-				log.info("다른 스레드에 의해 {} 단위가 업데이트 중입니다.", fromCurrency);
+				return monitorExchangeRateUpdate(fromCurrency, toCurrency, lock, condition);
 			}
-//		} catch (InterruptedException e) {
-//			log.error("{} ReentrantLock 획득 중 스레드 인터럽트 발생: {}", fromCurrency, e.getMessage());
-//		}
+		} catch (InterruptedException e) {
+			log.error("{} ReentrantLock 획득 중 스레드 인터럽트 발생: {}", fromCurrency, e.getMessage());
+			Thread.currentThread().interrupt();
+			throw new RuntimeException(e);
+		}
 	}
 
-	private void fallbackUpdate(Currency fromCurrency, Currency toCurrency) {
-		CompletableFuture
+	private BigDecimal fetchPrimaryExchangeRate(Currency fromCurrency, Currency toCurrency, ReentrantLock lock, Condition condition) {
+		try {
+			// double checking
+			if(isAvailableExchangeRate(fromCurrency, toCurrency)) {
+				return exchangeRateResults.get(fromCurrency).exchangeRate;
+			}
+
+			return CompletableFuture
+				.supplyAsync(() -> naverService.getExchangeRate(fromCurrency, toCurrency))
+				.orTimeout(OPEN_API_TIMEOUT, TimeUnit.MILLISECONDS)
+				.thenApply(result -> new BigDecimal(result.toString())
+					.setScale(2, RoundingMode.CEILING))
+				.thenApply(exchangeRate -> {
+					updateExchangeRateStatus(fromCurrency, exchangeRate);
+
+					log.info("[Main(Naver)] {} 환율 {} 업데이트, {}",
+						fromCurrency,
+						exchangeRate,
+						formatter.format(Instant.ofEpochMilli(exchangeRateResults.get(fromCurrency).lastCachedTime)));
+
+					return exchangeRate;
+				})
+				.exceptionally(ex -> {
+					log.error("Naver API failed or timed out, calling Manana and Google... {}", ex.getMessage());
+					return fetchFallbackExchangeRate(fromCurrency, toCurrency);
+				}).join();
+		} finally {
+			synchronized (condition) {
+				condition.notifyAll();
+			}
+			lock.unlock();
+		}
+	}
+
+	private BigDecimal fetchFallbackExchangeRate(Currency fromCurrency, Currency toCurrency) {
+		return CompletableFuture
 			.anyOf(
 				CompletableFuture
 					.supplyAsync(() -> mananaService.getExchangeRate(fromCurrency, toCurrency))
-					.orTimeout(CACHE_EXPIRY_TIME, TimeUnit.MILLISECONDS),
+					.orTimeout(OPEN_API_TIMEOUT, TimeUnit.MILLISECONDS),
 
 				CompletableFuture
 					.supplyAsync(() -> googleFinanceScraper.getExchangeRate(fromCurrency, toCurrency))
-					.orTimeout(CACHE_EXPIRY_TIME, TimeUnit.MILLISECONDS))
-
+					.orTimeout(OPEN_API_TIMEOUT, TimeUnit.MILLISECONDS)
+			)
 			.thenApply(result -> new BigDecimal(result.toString())
 				.setScale(2, RoundingMode.CEILING))
 			.thenApply(exchangeRate -> {
@@ -109,22 +125,45 @@ public class ExchangeRateService {
 			.join();
 	}
 
+	private BigDecimal monitorExchangeRateUpdate(Currency fromCurrency, Currency toCurrency, ReentrantLock lock, Condition condition) throws InterruptedException {
+		try {
+			// double checking
+			if(isAvailableExchangeRate(fromCurrency, toCurrency)) {
+				return exchangeRateResults.get(fromCurrency).exchangeRate;
+			}
+
+			log.info("다른 스레드에 의해 {} 단위가 업데이트 중입니다.", fromCurrency);
+
+			while (!isAvailableExchangeRate(fromCurrency, toCurrency)) {
+				if(lock.tryLock(TRY_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
+					return fetchPrimaryExchangeRate(fromCurrency, toCurrency, lock, condition);
+				}
+				else {
+					synchronized (condition) {
+						condition.wait(CONDITION_WAIT_TIMEOUT);
+					}
+				}
+			}
+			return exchangeRateResults.get(fromCurrency).exchangeRate;
+		} finally {
+			if(lock.isHeldByCurrentThread()) {
+				lock.unlock();
+			}
+		}
+	}
+
 	private void updateExchangeRateStatus(Currency fromCurrency, BigDecimal exchangeRate) {
 		ExchangeRateStatus status = exchangeRateResults.computeIfAbsent(fromCurrency, k -> new ExchangeRateStatus());
 		status.exchangeRate = exchangeRate;
 		status.lastCachedTime = System.currentTimeMillis();
 	}
 
-	public boolean isAvailableExchangeRate(Currency fromCurrency, Currency toCurrency) {
+	private boolean isAvailableExchangeRate(Currency fromCurrency, Currency toCurrency) {
 		return exchangeRateResults.containsKey(fromCurrency)
 			&& System.currentTimeMillis() - exchangeRateResults.get(fromCurrency).lastCachedTime < CACHE_EXPIRY_TIME;
 	}
 
-	public BigDecimal getExchangeRate(Currency fromCurrency, Currency toCurrency) {
-		return exchangeRateResults.get(fromCurrency).exchangeRate;
-	}
-
-	class ExchangeRateStatus {
+	static class ExchangeRateStatus {
 		BigDecimal exchangeRate;
 		Long lastCachedTime;
 

--- a/src/main/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateService.java
+++ b/src/main/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateService.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Condition;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
 
 @Service
@@ -30,13 +30,13 @@ public class ExchangeRateService {
 	private final ExchangeRateGoogleFinanceScraper googleFinanceScraper;
 
 	private static final Map<Currency, ReentrantLock> currencyLocks = new ConcurrentHashMap<>();
-	private static final Map<Currency, Condition> currencyConditions = new ConcurrentHashMap<>();
+	private static final Map<Currency, CompletableFuture<BigDecimal>> currencyFutures = new ConcurrentHashMap<>();
 	private static final Map<Currency, ExchangeRateStatus> exchangeRateResults = new ConcurrentHashMap<>();
 
 	private static final long TRY_LOCK_TIMEOUT = 1;
 	private static final long CACHE_EXPIRY_TIME = 2000;
 	private static final long OPEN_API_TIMEOUT = 2000;
-	private static final long CONDITION_WAIT_TIMEOUT = 3000;
+	private static final long FUTURE_TIMEOUT = 2000;
 
 	private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 		.withZone(ZoneId.systemDefault());
@@ -47,28 +47,27 @@ public class ExchangeRateService {
 		}
 
 		ReentrantLock lock = currencyLocks.computeIfAbsent(fromCurrency, k -> new ReentrantLock());
-		Condition condition = currencyConditions.computeIfAbsent(fromCurrency, k -> lock.newCondition());
+		CompletableFuture<BigDecimal> future = currencyFutures.computeIfAbsent(fromCurrency, k -> new CompletableFuture<>());
 		try {
 			if (lock.tryLock(TRY_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
-				return fetchPrimaryExchangeRate(fromCurrency, toCurrency, lock, condition);
+				return fetchPrimaryExchangeRate(fromCurrency, toCurrency, lock, future);
 			} else {
-				return monitorExchangeRateUpdate(fromCurrency, toCurrency, lock, condition);
+				return monitorExchangeRateUpdate(fromCurrency, toCurrency, lock, future);
 			}
 		} catch (InterruptedException e) {
-			log.error("{} ReentrantLock 획득 중 스레드 인터럽트 발생: {}", fromCurrency, e.getMessage());
+			log.error("{} ReentrantLock 획득 중 스레드 인터럽트 발생", fromCurrency, e);
 			Thread.currentThread().interrupt();
 			throw new RuntimeException(e);
+		} catch (Exception e) {
+			log.error("{} 환율 조회 중 예상치 못한 예외 발생", fromCurrency, e);
+			throw new RuntimeException(e);
 		}
+
 	}
 
-	private BigDecimal fetchPrimaryExchangeRate(Currency fromCurrency, Currency toCurrency, ReentrantLock lock, Condition condition) {
+	private BigDecimal fetchPrimaryExchangeRate(Currency fromCurrency, Currency toCurrency, ReentrantLock lock, CompletableFuture<BigDecimal> future) {
 		try {
-			// double checking
-			if(isAvailableExchangeRate(fromCurrency, toCurrency)) {
-				return exchangeRateResults.get(fromCurrency).exchangeRate;
-			}
-
-			return CompletableFuture
+			BigDecimal latestExchangeRate = CompletableFuture
 				.supplyAsync(() -> naverService.getExchangeRate(fromCurrency, toCurrency))
 				.orTimeout(OPEN_API_TIMEOUT, TimeUnit.MILLISECONDS)
 				.thenApply(result -> new BigDecimal(result.toString())
@@ -87,12 +86,13 @@ public class ExchangeRateService {
 					log.error("Naver API failed or timed out, calling Manana and Google... {}", ex.getMessage());
 					return fetchFallbackExchangeRate(fromCurrency, toCurrency);
 				}).join();
+
+			future.complete(latestExchangeRate);
+			return latestExchangeRate;
 		} finally {
-			synchronized (condition) {
-				condition.notifyAll();
-			}
 			lock.unlock();
 		}
+
 	}
 
 	private BigDecimal fetchFallbackExchangeRate(Currency fromCurrency, Currency toCurrency) {
@@ -125,31 +125,40 @@ public class ExchangeRateService {
 			.join();
 	}
 
-	private BigDecimal monitorExchangeRateUpdate(Currency fromCurrency, Currency toCurrency, ReentrantLock lock, Condition condition) throws InterruptedException {
-		try {
-			// double checking
-			if(isAvailableExchangeRate(fromCurrency, toCurrency)) {
-				return exchangeRateResults.get(fromCurrency).exchangeRate;
-			}
+	private BigDecimal monitorExchangeRateUpdate(Currency fromCurrency, Currency toCurrency, ReentrantLock lock, CompletableFuture<BigDecimal> future) throws InterruptedException {
+		// double checking
+		if(isAvailableExchangeRate(fromCurrency, toCurrency)) {
+			return exchangeRateResults.get(fromCurrency).exchangeRate;
+		}
 
-			log.info("다른 스레드에 의해 {} 단위가 업데이트 중입니다.", fromCurrency);
+		log.info("다른 스레드에 의해 {} 단위가 업데이트 중입니다.", fromCurrency);
 
-			while (!isAvailableExchangeRate(fromCurrency, toCurrency)) {
-				if(lock.tryLock(TRY_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
-					return fetchPrimaryExchangeRate(fromCurrency, toCurrency, lock, condition);
-				}
-				else {
-					synchronized (condition) {
-						condition.wait(CONDITION_WAIT_TIMEOUT);
+		return future.orTimeout(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS)
+			.thenApply(result -> {
+				log.info("업데이트된 환율({}, {}) 사용", fromCurrency, result);
+				return result;
+			})
+			.exceptionally(ex -> {
+				log.warn("{} 환율 업데이트 대기 시간 초과, 직접 환율 Open API 시도", fromCurrency);
+				try {
+					// 생산자 스레드의 알 수 없는 오류로 직접 Open API 직접 호출, 소비자 -> 생산자 역할 전환
+					if (lock.tryLock(TRY_LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
+						return fetchPrimaryExchangeRate(fromCurrency, toCurrency, lock, future);
+					} else {  // ReentrantLock 획득 실패, 마지막 대기 시도
+						return future.get(FUTURE_TIMEOUT, TimeUnit.MILLISECONDS);
+					}
+				} catch (TimeoutException e) {
+					log.error("환율 데이터 대기 시간 초과", e);
+					throw new RuntimeException(e);
+				} catch (Exception e) {
+					log.error("환율 조회 중 예상치 못한 예외 발생", e);
+					throw new RuntimeException(e);
+				} finally {
+					if (lock.isHeldByCurrentThread()) {
+						lock.unlock();
 					}
 				}
-			}
-			return exchangeRateResults.get(fromCurrency).exchangeRate;
-		} finally {
-			if(lock.isHeldByCurrentThread()) {
-				lock.unlock();
-			}
-		}
+			}).join();
 	}
 
 	private void updateExchangeRateStatus(Currency fromCurrency, BigDecimal exchangeRate) {

--- a/src/main/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/naver/ExchangeRateNaverService.java
+++ b/src/main/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/naver/ExchangeRateNaverService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 @Service
 @RequiredArgsConstructor
@@ -61,6 +62,6 @@ public class ExchangeRateNaverService {
 
 	private BigDecimal convertToBigDecimal(String value) {
 		value = value.replace(",", "");
-		return new BigDecimal(value);
+		return new BigDecimal(value).setScale(2, RoundingMode.CEILING);
 	}
 }

--- a/src/main/java/com/nayoung/exchangerateopenapitest/domain/transaction/service/TransactionService.java
+++ b/src/main/java/com/nayoung/exchangerateopenapitest/domain/transaction/service/TransactionService.java
@@ -36,34 +36,10 @@ public class TransactionService {
 			exchangeRate = new BigDecimal(1);
 		}
 		else {
-			long currentTime = System.currentTimeMillis();
-			long timeout = 4000;
-			long endTime = currentTime + timeout;
-
-			boolean timeoutFlag = true;
-			while (System.currentTimeMillis() < endTime) {
-				// 로컬 캐시 사용
-				if (exchangeRateService.isAvailableExchangeRate(receiverAccount.getCurrency(), senderAccount.getCurrency())) {
-					exchangeRate = exchangeRateService.getExchangeRate(receiverAccount.getCurrency(), senderAccount.getCurrency());
-					timeoutFlag = false;
-					break;
-				}
-
-				// 실시간 환율 데이터 업데이트 (스레드 1개로 제한)
-				exchangeRateService.updateExchangeRate(receiverAccount.getCurrency(), senderAccount.getCurrency());
-
-				try {
-					if (!exchangeRateService.isAvailableExchangeRate(receiverAccount.getCurrency(), senderAccount.getCurrency())) {
-						Thread.sleep(150);
-					}
-				} catch (InterruptedException e) {
-					Thread.currentThread().interrupt();
-					throw new RuntimeException("환율 조회 중 인터럽트 발생", e);
-				}
-			}
-
-			if (timeoutFlag || exchangeRate.compareTo(BigDecimal.ZERO) <= 0) {
-				log.warn("[ Timeout ] 현재 실시간 환율을 이용할 수 없습니다. " + Thread.currentThread().getName());
+			try {
+				exchangeRate = exchangeRateService.getLatestExchangeRate(receiverAccount.getCurrency(), senderAccount.getCurrency());
+			} catch (Exception e) {
+				log.warn("[ Timeout ] 현재 실시간 환율을 이용할 수 없습니다.", e);
 				throw new RuntimeException("현재 실시간 환율을 이용할 수 없습니다.");
 			}
 		}

--- a/src/test/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateServiceMockTest.java
+++ b/src/test/java/com/nayoung/exchangerateopenapitest/domain/exchangerate/ExchangeRateServiceMockTest.java
@@ -37,7 +37,7 @@ class ExchangeRateServiceMockTest {
 		for(int i = 0; i < threadCount; i++) {
 			executorService.submit(() -> {
 				try {
-					exchangeRateService.updateExchangeRate(Currency.USD, Currency.KRW);
+					exchangeRateService.getLatestExchangeRate(Currency.USD, Currency.KRW);
 				} finally {
 					countDownLatch.countDown();
 				}


### PR DESCRIPTION
### CompletableFuture complete, get 설정

- lock 없이 synchronized(condition) {} 사용은... 아무리 생각해도 기술의 특징을 살리지 못한 코드라 생각해 condition 제거
- 소비자: future.get() (orTimeout) 호출
- 생산자: future.complete() 호출
